### PR TITLE
Rate limiting now also works for API-key based authentication.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 #### Bugfixes
   - Better stack traces when the timeout handler is used (#19)
+  - Rate limiting now also works for API-key based authentication (#20)
 
 ## v0.5.1 (2022-03-23)
 #### Bugfixes
@@ -11,5 +12,5 @@
 
 ## v0.5.0 (2022-03-18)
 #### New features
-  - Support for API-based authentication (Skolsynk) (#11)
+  - Support for API-key based authentication (Skolsynk) (#11)
   - We will now retry DB connection if it fails at startup (#13)

--- a/cmd/windermere/limiter.go
+++ b/cmd/windermere/limiter.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/Sambruk/windermere/scimserverlite"
+	"golang.org/x/time/rate"
+)
+
+// Limiter returns a middleware with token bucket rate limiting applied per tenant
+func Limiter(h http.Handler, tenantGetter scimserverlite.TenantGetter, r rate.Limit, b int) http.Handler {
+
+	limiters := make(map[string]*rate.Limiter)
+	var lock sync.Mutex
+
+	getLimiter := func(entity string) *rate.Limiter {
+		lock.Lock()
+		defer lock.Unlock()
+
+		if limiter, ok := limiters[entity]; ok {
+			return limiter
+		}
+		limiter := rate.NewLimiter(r, b)
+		limiters[entity] = limiter
+		return limiter
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limiter := getLimiter(tenantGetter(r.Context()))
+
+		if limiter.Wait(r.Context()) != nil {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/cmd/windermere/main.go
+++ b/cmd/windermere/main.go
@@ -228,7 +228,7 @@ func main() {
 	enableLimiting := viper.GetBool(CNFEnableLimiting)
 
 	if enableLimiting {
-		handler = server.Limiter(handler,
+		handler = Limiter(handler, tenantGetter,
 			rate.Limit(viper.GetFloat64(CNFLimitRequestsPerSecond)),
 			viper.GetInt(CNFLimitBurst))
 	}


### PR DESCRIPTION
Fixes #20